### PR TITLE
支持dst是结构体类型，src是结构体指针类型的拷贝

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -200,6 +200,10 @@ func (d *deepCopy) checkCycle(sField reflect.Value) error {
 func (d *deepCopy) cpyStruct(dst, src reflect.Value, depth int) error {
 
 	if dst.Kind() != src.Kind() {
+		if dst.Kind() == reflect.Ptr && !dst.IsNil() {
+			dst = dst.Elem()
+			return d.cpyStruct(dst, src, depth)
+		}
 		return nil
 	}
 
@@ -265,7 +269,7 @@ func (d *deepCopy) cpyPtr(dst, src reflect.Value, depth int) error {
 
 	if dst.IsNil() {
 		// dst.CanSet必须放到dst.IsNil判断里面
-		// 不让会影响到struct或者map类型的指针
+		// 不然会影响到struct或者map类型的指针
 		if !dst.CanSet() {
 			return nil
 		}

--- a/deepcopy_better_to_use_test.go
+++ b/deepcopy_better_to_use_test.go
@@ -1,0 +1,29 @@
+package deepcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testBetterToUse struct {
+	Str string
+	ID  int
+}
+
+// src是指针类型的结构体
+// dst是普通结构体
+func Test_srcPtr_DstBaseType(t *testing.T) {
+
+	t1 := testBetterToUse{Str: "hello", ID: 1}
+	t2 := testBetterToUse{}
+	Copy(&t2, t1).Do()
+	assert.Equal(t, t1, t2)
+}
+
+func Test_srcPtr_DstBaseType_NotPanics(t *testing.T) {
+	t1 := testBetterToUse{Str: "hello", ID: 1}
+	assert.NotPanics(t, func() {
+		Copy((*testBetterToUse)(nil), t1).Do()
+	})
+}


### PR DESCRIPTION
支持dst是结构体，src是结构体指针的非对称拷贝。
```go
        type testBetterToUse struct {
	        Str string
	        ID  int
        }
        t1 := testBetterToUse{Str: "hello", ID: 1}
	t2 := testBetterToUse{}
	Copy(&t2, t1).Do()
```