### PR TITLE
优化, src是双指针的情况, 也可以正常拷贝

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -263,11 +263,8 @@ func (d *deepCopy) cpyInterface(dst, src reflect.Value, depth int) error {
 
 // 拷贝指针
 func (d *deepCopy) cpyPtr(dst, src reflect.Value, depth int) error {
-	if dst.Kind() != src.Kind() {
-		return nil
-	}
 
-	if dst.IsNil() {
+	if dst.Kind() == reflect.Ptr && dst.IsNil() {
 		// dst.CanSet必须放到dst.IsNil判断里面
 		// 不然会影响到struct或者map类型的指针
 		if !dst.CanSet() {
@@ -277,8 +274,13 @@ func (d *deepCopy) cpyPtr(dst, src reflect.Value, depth int) error {
 		dst.Set(p)
 	}
 
-	src = src.Elem()
-	dst = dst.Elem()
+	if src.Kind() == reflect.Ptr {
+		src = src.Elem()
+	}
+
+	if dst.Kind() == reflect.Ptr {
+		dst = dst.Elem()
+	}
 
 	return d.deepCopy(dst, src, depth)
 }

--- a/deepcopy_src_double_ptr_test.go
+++ b/deepcopy_src_double_ptr_test.go
@@ -1,0 +1,30 @@
+package deepcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Msg struct {
+	FromUid int32  `protobuf:"varint,1,opt,name=from_uid,json=fromUid,proto3" json:"from_uid,omitempty"`
+	ToUid   int32  `protobuf:"varint,2,opt,name=to_uid,json=toUid,proto3" json:"to_uid,omitempty"`
+	Msg     string `protobuf:"bytes,3,opt,name=msg,proto3" json:"msg,omitempty"`
+}
+
+// 测试src是双指针的情况
+// 为了提升deepcopy库的兼容性, src是双指针, dst是单指针, 也可以正常拷贝
+func Test_Src_DoublePtr_Test(t *testing.T) {
+	m1 := Msg{FromUid: 1, ToUid: 2, Msg: "1to2"}
+
+	// 单指针
+	m1Ptr := &m1
+
+	var m2 Msg
+	//dst(m2) 是单指针
+	//src(m1Ptr) 是双指针
+	err := Copy(&m2, &m1Ptr).Do()
+
+	assert.NoError(t, err)
+	assert.Equal(t, m1, m2)
+}

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
```go
package deepcopy

import (
	"testing"

	"github.com/stretchr/testify/assert"
)

type Msg struct {
	FromUid int32  `protobuf:"varint,1,opt,name=from_uid,json=fromUid,proto3" json:"from_uid,omitempty"`
	ToUid   int32  `protobuf:"varint,2,opt,name=to_uid,json=toUid,proto3" json:"to_uid,omitempty"`
	Msg     string `protobuf:"bytes,3,opt,name=msg,proto3" json:"msg,omitempty"`
}

// 测试src是双指针的情况
// 为了提升deepcopy库的兼容性, src是双指针, dst是单指针, 也可以正常拷贝
func Test_Src_DoublePtr_Test(t *testing.T) {
	m1 := Msg{FromUid: 1, ToUid: 2, Msg: "1to2"}

	// 单指针
	m1Ptr := &m1

	var m2 Msg
	//dst(m2) 是单指针
	//src(m1Ptr) 是双指针
	err := Copy(&m2, &m1Ptr).Do()

	assert.NoError(t, err)
	assert.Equal(t, m1, m2)
}

```